### PR TITLE
CHG: Allow to skip config providers for certain commands

### DIFF
--- a/priv/libexec/config.sh
+++ b/priv/libexec/config.sh
@@ -96,24 +96,26 @@ configure_release() {
     fi
     export SYS_CONFIG_PATH="${DEST_SYS_CONFIG_PATH:-$SYS_CONFIG_PATH}"
 
-    if [ -z "$RELEASE_READ_ONLY" ]; then
-        # Now that we have a full base config, run the config providers pass
-        # This will replace the config at SYS_CONFIG_PATH with a fully provisioned config
-        # Set the logger level to warning to prevent unnecessary output to stdio
-        if [ -z "$DEBUG_BOOT" ]; then
-            # Silence all output when not debugging, but print errors
-            set +e
-            err="$(erl -noshell -config "$SYS_CONFIG_PATH" -boot "${REL_DIR}/config" -s erlang halt)"
-            status=$?
-            set -e
-            if [ $status -ne 0 ]; then
-                echo "$err"
-                fail "Unable to configure release!"
-            fi
-        else
-            # Otherwise, show any output produced
-            if ! erl -noshell -config "$SYS_CONFIG_PATH" -boot "${REL_DIR}/config" -s erlang halt; then
-                fail "Unable to configure release!"
+    if [ "$SKIP_CONFIG_PROVIDERS" != true ]; then
+        if [ -z "$RELEASE_READ_ONLY" ]; then
+            # Now that we have a full base config, run the config providers pass
+            # This will replace the config at SYS_CONFIG_PATH with a fully provisioned config
+            # Set the logger level to warning to prevent unnecessary output to stdio
+            if [ -z "$DEBUG_BOOT" ]; then
+                # Silence all output when not debugging, but print errors
+                set +e
+                err="$(erl -noshell -config "$SYS_CONFIG_PATH" -boot "${REL_DIR}/config" -s erlang halt)"
+                status=$?
+                set -e
+                if [ $status -ne 0 ]; then
+                    echo "$err"
+                    fail "Unable to configure release!"
+                fi
+            else
+                # Otherwise, show any output produced
+                if ! erl -noshell -config "$SYS_CONFIG_PATH" -boot "${REL_DIR}/config" -s erlang halt; then
+                    fail "Unable to configure release!"
+                fi
             fi
         fi
     fi

--- a/priv/templates/release_rc_main.eex
+++ b/priv/templates/release_rc_main.eex
@@ -120,6 +120,11 @@ case $COMMAND_NAME in
         configure_release
         . "$COMMAND_DIR/console.sh" "$COMMAND_NAME" "$@"
         ;;
+    ping|remote_console|stop)
+        SKIP_CONFIG_PROVIDERS=true
+        configure_release
+        . "$COMMAND_PATH" "$@"
+        ;;
     *)
         # If the command exists in libexec, execute
         # Otherwise check to see if it's the name of a custom command


### PR DESCRIPTION
### Summary of changes
ping/remote_console/stop operations need to skip config providers steps to prevent excessive config overloading
